### PR TITLE
Improve CORS compatibility and allow JSON body for user auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN pip install tornado
 RUN pip install PyJWT
 RUN pip install pycrypto
 RUN pip install PyYaml
+RUN pip install tornado-cors
 
 #add the files into image
 RUN mkdir -p /root/esp8266_iot_node


### PR DESCRIPTION
Add tornado-cors to shim in better CORS compliance (namely responding to the empty OPTIONS request) and allow user auth data to be POSTed as JSON
data in the body. Also add a try-catch in BaseHandler for when failure_reason isn't defined.

Also remove Access-Control-Allow-Origin header since the CorsMixin handles that now.
